### PR TITLE
Create project wizard is missing new variables from archetype

### DIFF
--- a/com.adobe.granite.ide.eclipse-ui/src/main/java/com/adobe/granite/ide/eclipse/ui/wizards/np/AdvancedSettingsComponent.java
+++ b/com.adobe.granite.ide.eclipse-ui/src/main/java/com/adobe/granite/ide/eclipse/ui/wizards/np/AdvancedSettingsComponent.java
@@ -305,6 +305,8 @@ public class AdvancedSettingsComponent extends ExpandableComposite {
                 text = defaultAppsName;
             } else if (rp.getKey().equals("contentFolderName")) {
                 text = defaultAppsName;
+            } else if (rp.getKey().equals("confFolderName")) {
+                text = defaultAppsName;
             } else if (rp.getKey().equals("cssId")) {
                 text = artifactId;
             } else if (rp.getKey().equals("componentGroupName")) {


### PR DESCRIPTION
Adds check for missing "confFolderName" when handling text modification of name, groupId or artifactId