### PR TITLE
Issue127 Remove Deprecated API calls

### DIFF
--- a/com.adobe.granite.ide.eclipse-ui/src/main/java/com/adobe/granite/ide/eclipse/ui/perspectives/GranitePerspective.java
+++ b/com.adobe.granite.ide.eclipse-ui/src/main/java/com/adobe/granite/ide/eclipse/ui/perspectives/GranitePerspective.java
@@ -46,7 +46,7 @@ public class GranitePerspective implements IPerspectiveFactory {
 	}
 
 	private void addViews() {
-		// Creates the overall folder layout. 
+		// Creates the overall layout for the AEM Perspective. 
 		// Note that each new Folder uses a percentage of the remaining EditorArea.
 		
         IFolderLayout veryBottom =
@@ -120,6 +120,7 @@ public class GranitePerspective implements IPerspectiveFactory {
 	}
 
 	private void addViewShortcuts() {
+		// Add entries for the Window/Show View menu
 		factory.addShowViewShortcut("org.eclipse.ant.ui.views.AntView"); //NON-NLS-1
 		factory.addShowViewShortcut("org.eclipse.pde.ui.DependenciesView"); //NON-NLS-1
 		factory.addShowViewShortcut("org.eclipse.jdt.junit.ResultView"); //NON-NLS-1

--- a/com.adobe.granite.ide.eclipse-ui/src/main/java/com/adobe/granite/ide/eclipse/ui/perspectives/GranitePerspective.java
+++ b/com.adobe.granite.ide.eclipse-ui/src/main/java/com/adobe/granite/ide/eclipse/ui/perspectives/GranitePerspective.java
@@ -65,7 +65,6 @@ public class GranitePerspective implements IPerspectiveFactory {
 					0.3f,
 					factory.getEditorArea());
 		left.addView(IPageLayout.ID_PROJECT_EXPLORER);
-		left.addPlaceholder(IPageLayout.ID_RES_NAV);
 		
 		IFolderLayout leftMiddle =
 				factory.createFolder(
@@ -94,9 +93,6 @@ public class GranitePerspective implements IPerspectiveFactory {
 						0.75f,
 						factory.getEditorArea());
 		right.addView(IPageLayout.ID_OUTLINE);
-		
-		factory.addFastView("org.eclipse.team.ccvs.ui.RepositoriesView",0.50f); //NON-NLS-1
-		factory.addFastView("org.eclipse.team.sync.views.SynchronizeView", 0.50f); //NON-NLS-1
 	}
 
 	private void addActionSets() {
@@ -132,9 +128,10 @@ public class GranitePerspective implements IPerspectiveFactory {
 		factory.addShowViewShortcut("org.eclipse.pde.ui.DependenciesView"); //NON-NLS-1
 		factory.addShowViewShortcut("org.eclipse.jdt.junit.ResultView"); //NON-NLS-1
 		factory.addShowViewShortcut("org.eclipse.team.ui.GenericHistoryView"); //NON-NLS-1
+		factory.addShowViewShortcut("org.eclipse.team.ccvs.ui.RepositoriesView"); //NON-NLS-1
+		factory.addShowViewShortcut("org.eclipse.team.sync.views.SynchronizeView"); //NON-NLS-1
 		factory.addShowViewShortcut(IConsoleConstants.ID_CONSOLE_VIEW);
 		factory.addShowViewShortcut(JavaUI.ID_PACKAGES);
-		factory.addShowViewShortcut(IPageLayout.ID_RES_NAV);
 		factory.addShowViewShortcut(IPageLayout.ID_PROBLEM_VIEW);
 		factory.addShowViewShortcut(IPageLayout.ID_OUTLINE);
 	}

--- a/com.adobe.granite.ide.eclipse-ui/src/main/java/com/adobe/granite/ide/eclipse/ui/perspectives/GranitePerspective.java
+++ b/com.adobe.granite.ide.eclipse-ui/src/main/java/com/adobe/granite/ide/eclipse/ui/perspectives/GranitePerspective.java
@@ -102,7 +102,6 @@ public class GranitePerspective implements IPerspectiveFactory {
 		factory.addActionSet("org.eclipse.jdt.debug.ui.JDTDebugActionSet"); //NON-NLS-1
 		factory.addActionSet("org.eclipse.jdt.junit.JUnitActionSet"); //NON-NLS-1
 		factory.addActionSet("org.eclipse.team.ui.actionSet"); //NON-NLS-1
-		factory.addActionSet("org.eclipse.team.cvs.ui.CVSActionSet"); //NON-NLS-1
 		factory.addActionSet("org.eclipse.ant.ui.actionSet.presentation"); //NON-NLS-1
 		factory.addActionSet(JavaUI.ID_ACTION_SET);
 		factory.addActionSet(JavaUI.ID_ELEMENT_CREATION_ACTION_SET);
@@ -111,25 +110,20 @@ public class GranitePerspective implements IPerspectiveFactory {
 
 	private void addPerspectiveShortcuts() {
 		factory.addPerspectiveShortcut("org.eclipse.team.ui.TeamSynchronizingPerspective"); //NON-NLS-1
-		factory.addPerspectiveShortcut("org.eclipse.team.cvs.ui.cvsPerspective"); //NON-NLS-1
 		factory.addPerspectiveShortcut("org.eclipse.ui.resourcePerspective"); //NON-NLS-1
 	}
 
 	private void addNewWizardShortcuts() {
 		factory.addNewWizardShortcut("org.apache.sling.ide.eclipse.ui.wizards.NewSlingProjectWizard");//NON-NLS-1
-		factory.addNewWizardShortcut("org.eclipse.team.cvs.ui.newProjectCheckout");//NON-NLS-1
 		factory.addNewWizardShortcut("org.eclipse.ui.wizards.new.folder");//NON-NLS-1
 		factory.addNewWizardShortcut("org.eclipse.ui.wizards.new.file");//NON-NLS-1
 	}
 
 	private void addViewShortcuts() {
 		factory.addShowViewShortcut("org.eclipse.ant.ui.views.AntView"); //NON-NLS-1
-		factory.addShowViewShortcut("org.eclipse.team.ccvs.ui.AnnotateView"); //NON-NLS-1
 		factory.addShowViewShortcut("org.eclipse.pde.ui.DependenciesView"); //NON-NLS-1
 		factory.addShowViewShortcut("org.eclipse.jdt.junit.ResultView"); //NON-NLS-1
 		factory.addShowViewShortcut("org.eclipse.team.ui.GenericHistoryView"); //NON-NLS-1
-		factory.addShowViewShortcut("org.eclipse.team.ccvs.ui.RepositoriesView"); //NON-NLS-1
-		factory.addShowViewShortcut("org.eclipse.team.sync.views.SynchronizeView"); //NON-NLS-1
 		factory.addShowViewShortcut(IConsoleConstants.ID_CONSOLE_VIEW);
 		factory.addShowViewShortcut(JavaUI.ID_PACKAGES);
 		factory.addShowViewShortcut(IPageLayout.ID_PROBLEM_VIEW);


### PR DESCRIPTION
## Description

Removed the calls to parts of the Eclipse UI that have been deprecated (specifically the Resource View and the CVS Team plugin).  Migrated the `addFastView()` method calls to `addShowViewShortcut()` and moved the migrated calls to `addViewShortcuts()`. Added a couple of clarifying comments.

## Related Issue

Closes #127 

## Motivation and Context

The code in this plugin has not been maintained for some time and it contains references to elements of the Eclipse runtime that are either deprecated for removal or have already been removed.  This PR removes those references.

## How Has This Been Tested?

Installed the updated plugin into a local Eclipse instance and verified that the AEM perspective still works.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
